### PR TITLE
Fix build by removing unused import

### DIFF
--- a/cmd/ansible-operator/main.go
+++ b/cmd/ansible-operator/main.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path/filepath"
 	"runtime"
 
 	proxy "github.com/automationbroker/ansible-operator/pkg/proxy"
@@ -18,8 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
When trying to build locally (I'm new to Go so possible I am missing something locally) I hit the following output:

```
ehelms@war ansible-operator (master)$ operator-sdk build quay.io/ehelms/ansible-operator
Error: failed to build: (building ansible-operator...
# github.com/automationbroker/ansible-operator/cmd/ansible-operator
cmd/ansible-operator/main.go:7:2: imported and not used: "os"
cmd/ansible-operator/main.go:8:2: imported and not used: "path/filepath"
cmd/ansible-operator/main.go:21:2: imported and not used: "github.com/automationbroker/ansible-operator/vendor/k8s.io/client-go/rest"
cmd/ansible-operator/main.go:22:2: imported and not used: "github.com/automationbroker/ansible-operator/vendor/k8s.io/client-go/tools/clientcmd"
)
```